### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ class TagsCommand(Command):
         # Windows versions of etag do not seem to expand wildcards (which Unix shells normally do for Unix utilities),
         # so find all of the files ourselves.
         files = [ join('src', f) for f in os.listdir('src') if f.endswith(('.h', '.cpp')) ]
-        cmd = 'etags %s' % ' '.join(files)
+        cmd = 'etags {0!s}'.format(' '.join(files))
         return os.system(cmd)
 
 
@@ -125,8 +125,8 @@ def get_compiler_settings(version_str):
     # command.
     for option in ['assert', 'trace', 'leak-check']:
         try:
-            sys.argv.remove('--%s' % option)
-            settings['define_macros'].append(('PYODBC_%s' % option.replace('-', '_').upper(), 1))
+            sys.argv.remove('--{0!s}'.format(option))
+            settings['define_macros'].append(('PYODBC_{0!s}'.format(option.replace('-', '_').upper()), 1))
         except ValueError:
             pass
 
@@ -253,7 +253,7 @@ def _get_version_pkginfo():
 def _get_version_git():
     n, result = getoutput('git describe --tags --match [0-9].[0-9].[0-9]')
     if n:
-        _print('WARNING: git describe failed with: %s %s' % (n, result))
+        _print('WARNING: git describe failed with: {0!s} {1!s}'.format(n, result))
         return None, None
 
     match = re.match(r'(\d+).(\d+).(\d+) (?: -(\d+)-g[0-9a-z]+)?', result, re.VERBOSE)
@@ -262,11 +262,11 @@ def _get_version_git():
 
     numbers = [int(n or OFFICIAL_BUILD) for n in match.groups()]
     if numbers[-1] == OFFICIAL_BUILD:
-        name = '%s.%s.%s' % tuple(numbers[:3])
+        name = '{0!s}.{1!s}.{2!s}'.format(*tuple(numbers[:3]))
     if numbers[-1] != OFFICIAL_BUILD:
         # This is a beta of the next micro release, so increment the micro number to reflect this.
         numbers[-2] += 1
-        name = '%s.%s.%sb%d' % tuple(numbers)
+        name = '{0!s}.{1!s}.{2!s}b{3:d}'.format(*tuple(numbers))
 
     n, result = getoutput('git rev-parse --abbrev-ref HEAD')
 

--- a/tests2/accesstests.py
+++ b/tests2/accesstests.py
@@ -79,7 +79,7 @@ class AccessTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -135,12 +135,12 @@ class AccessTestCase(unittest.TestCase):
         """
         The implementation for string, Unicode, and binary tests.
         """
-        assert colsize is None or (value is None or colsize >= len(value)), 'colsize=%s value=%s' % (colsize, (value is None) and 'none' or len(value))
+        assert colsize is None or (value is None or colsize >= len(value)), 'colsize={0!s} value={1!s}'.format(colsize, (value is None) and 'none' or len(value))
 
         if colsize:
-            sql = "create table t1(n1 int not null, s1 %s(%s), s2 %s(%s))" % (sqltype, colsize, sqltype, colsize)
+            sql = "create table t1(n1 int not null, s1 {0!s}({1!s}), s2 {2!s}({3!s}))".format(sqltype, colsize, sqltype, colsize)
         else:
-            sql = "create table t1(n1 int not null, s1 %s, s2 %s)" % (sqltype, sqltype)
+            sql = "create table t1(n1 int not null, s1 {0!s}, s2 {1!s})".format(sqltype, sqltype)
 
         if resulttype is None:
             # Access only uses Unicode, but strings might have been passed in to see if they can be written.  When we
@@ -177,10 +177,10 @@ class AccessTestCase(unittest.TestCase):
     def _maketest(value):
         def t(self):
             self._test_strtype('varchar', value, colsize=len(value))
-        t.__doc__ = 'unicode %s' % len(value)
+        t.__doc__ = 'unicode {0!s}'.format(len(value))
         return t
     for value in UNICODE_FENCEPOSTS:
-        locals()['test_unicode_%s' % len(value)] = _maketest(value)
+        locals()['test_unicode_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # ansi -> varchar
@@ -192,10 +192,10 @@ class AccessTestCase(unittest.TestCase):
     def _maketest(value):
         def t(self):
             self._test_strtype('varchar', value, colsize=len(value))
-        t.__doc__ = 'ansi %s' % len(value)
+        t.__doc__ = 'ansi {0!s}'.format(len(value))
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_ansivarchar_%s' % len(value)] = _maketest(value)
+        locals()['test_ansivarchar_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # binary
@@ -205,10 +205,10 @@ class AccessTestCase(unittest.TestCase):
     def _maketest(value):
         def t(self):
             self._test_strtype('varbinary', buffer(value), colsize=len(value), resulttype=pyodbc.BINARY)
-        t.__doc__ = 'binary %s' % len(value)
+        t.__doc__ = 'binary {0!s}'.format(len(value))
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_binary_%s' % len(value)] = _maketest(value)
+        locals()['test_binary_{0!s}'.format(len(value))] = _maketest(value)
 
 
     #
@@ -222,10 +222,10 @@ class AccessTestCase(unittest.TestCase):
     def _maketest(value):
         def t(self):
             self._test_strtype('image', buffer(value), resulttype=pyodbc.BINARY)
-        t.__doc__ = 'image %s' % len(value)
+        t.__doc__ = 'image {0!s}'.format(len(value))
         return t
     for value in IMAGE_FENCEPOSTS:
-        locals()['test_image_%s' % len(value)] = _maketest(value)
+        locals()['test_image_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # memo
@@ -238,19 +238,19 @@ class AccessTestCase(unittest.TestCase):
     def _maketest(value):
         def t(self):
             self._test_strtype('memo', unicode(value))
-        t.__doc__ = 'Unicode to memo %s' % len(value)
+        t.__doc__ = 'Unicode to memo {0!s}'.format(len(value))
         return t
     for value in IMAGE_FENCEPOSTS:
-        locals()['test_memo_%s' % len(value)] = _maketest(value)
+        locals()['test_memo_{0!s}'.format(len(value))] = _maketest(value)
 
     # ansi -> memo
     def _maketest(value):
         def t(self):
             self._test_strtype('memo', value)
-        t.__doc__ = 'ANSI to memo %s' % len(value)
+        t.__doc__ = 'ANSI to memo {0!s}'.format(len(value))
         return t
     for value in IMAGE_FENCEPOSTS:
-        locals()['test_ansimemo_%s' % len(value)] = _maketest(value)
+        locals()['test_ansimemo_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_subquery_params(self):
         """Ensure parameter markers work in a subquery"""
@@ -633,7 +633,7 @@ def main():
         driver = 'Microsoft Access Driver (*.mdb)'
 
     global CNXNSTRING
-    CNXNSTRING = 'DRIVER={%s};DBQ=%s;ExtendedAnsiSQL=1' % (driver, abspath(args[0]))
+    CNXNSTRING = 'DRIVER={{{0!s}}};DBQ={1!s};ExtendedAnsiSQL=1'.format(driver, abspath(args[0]))
 
     cnxn = pyodbc.connect(CNXNSTRING)
     print_library_info(cnxn)

--- a/tests2/dbapi20.py
+++ b/tests2/dbapi20.py
@@ -90,10 +90,10 @@ class DatabaseAPI20Test(unittest.TestCase):
     connect_kw_args = {} # Keyword arguments for connect
     table_prefix = 'dbapi20test_' # If you need to specify a prefix for tables
 
-    ddl1 = 'create table %sbooze (name varchar(20))' % table_prefix
-    ddl2 = 'create table %sbarflys (name varchar(20))' % table_prefix
-    xddl1 = 'drop table %sbooze' % table_prefix
-    xddl2 = 'drop table %sbarflys' % table_prefix
+    ddl1 = 'create table {0!s}booze (name varchar(20))'.format(table_prefix)
+    ddl2 = 'create table {0!s}barflys (name varchar(20))'.format(table_prefix)
+    xddl1 = 'drop table {0!s}booze'.format(table_prefix)
+    xddl2 = 'drop table {0!s}barflys'.format(table_prefix)
 
     lowerfunc = 'lower' # Name of stored procedure to convert string->lowercase
         
@@ -251,10 +251,10 @@ class DatabaseAPI20Test(unittest.TestCase):
             cur1 = con.cursor()
             cur2 = con.cursor()
             self.executeDDL1(cur1)
-            cur1.execute("insert into %sbooze values ('Victoria Bitter')" % (
+            cur1.execute("insert into {0!s}booze values ('Victoria Bitter')".format((
                 self.table_prefix
-                ))
-            cur2.execute("select name from %sbooze" % self.table_prefix)
+                )))
+            cur2.execute("select name from {0!s}booze".format(self.table_prefix))
             booze = cur2.fetchall()
             self.assertEqual(len(booze),1)
             self.assertEqual(len(booze[0]),1)
@@ -271,7 +271,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'cursor.description should be none after executing a '
                 'statement that can return no rows (such as DDL)'
                 )
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             self.assertEqual(len(cur.description),1,
                 'cursor.description describes too many columns'
                 )
@@ -282,8 +282,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'cursor.description[x][0] must return column name'
                 )
             self.assertEqual(cur.description[0][1],self.driver.STRING,
-                'cursor.description[x][1] must return column type. Got %r'
-                    % cur.description[0][1]
+                'cursor.description[x][1] must return column type. Got {0!r}'.format(cur.description[0][1])
                 )
 
             # Make sure self.description gets reset
@@ -304,14 +303,14 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'cursor.rowcount should be -1 after executing no-result '
                 'statements'
                 )
-            cur.execute("insert into %sbooze values ('Victoria Bitter')" % (
+            cur.execute("insert into {0!s}booze values ('Victoria Bitter')".format((
                 self.table_prefix
-                ))
+                )))
             self.failUnless(cur.rowcount in (-1,1),
                 'cursor.rowcount should == number or rows inserted, or '
                 'set to -1 after executing an insert statement'
                 )
-            cur.execute("select name from %sbooze" % self.table_prefix)
+            cur.execute("select name from {0!s}booze".format(self.table_prefix))
             self.failUnless(cur.rowcount in (-1,1),
                 'cursor.rowcount should == number of rows returned, or '
                 'set to -1 after executing a select statement'
@@ -372,41 +371,41 @@ class DatabaseAPI20Test(unittest.TestCase):
 
     def _paraminsert(self,cur):
         self.executeDDL1(cur)
-        cur.execute("insert into %sbooze values ('Victoria Bitter')" % (
+        cur.execute("insert into {0!s}booze values ('Victoria Bitter')".format((
             self.table_prefix
-            ))
+            )))
         self.failUnless(cur.rowcount in (-1,1))
 
         if self.driver.paramstyle == 'qmark':
             cur.execute(
-                'insert into %sbooze values (?)' % self.table_prefix,
+                'insert into {0!s}booze values (?)'.format(self.table_prefix),
                 ("Cooper's",)
                 )
         elif self.driver.paramstyle == 'numeric':
             cur.execute(
-                'insert into %sbooze values (:1)' % self.table_prefix,
+                'insert into {0!s}booze values (:1)'.format(self.table_prefix),
                 ("Cooper's",)
                 )
         elif self.driver.paramstyle == 'named':
             cur.execute(
-                'insert into %sbooze values (:beer)' % self.table_prefix, 
+                'insert into {0!s}booze values (:beer)'.format(self.table_prefix), 
                 {'beer':"Cooper's"}
                 )
         elif self.driver.paramstyle == 'format':
             cur.execute(
-                'insert into %sbooze values (%%s)' % self.table_prefix,
+                'insert into {0!s}booze values (%s)'.format(self.table_prefix),
                 ("Cooper's",)
                 )
         elif self.driver.paramstyle == 'pyformat':
             cur.execute(
-                'insert into %sbooze values (%%(beer)s)' % self.table_prefix,
+                'insert into {0!s}booze values (%(beer)s)'.format(self.table_prefix),
                 {'beer':"Cooper's"}
                 )
         else:
             self.fail('Invalid paramstyle')
         self.failUnless(cur.rowcount in (-1,1))
 
-        cur.execute('select name from %sbooze' % self.table_prefix)
+        cur.execute('select name from {0!s}booze'.format(self.table_prefix))
         res = cur.fetchall()
         self.assertEqual(len(res),2,'cursor.fetchall returned too few rows')
         beers = [res[0][0],res[1][0]]
@@ -429,29 +428,29 @@ class DatabaseAPI20Test(unittest.TestCase):
             margs = [ {'beer': "Cooper's"}, {'beer': "Boag's"} ]
             if self.driver.paramstyle == 'qmark':
                 cur.executemany(
-                    'insert into %sbooze values (?)' % self.table_prefix,
+                    'insert into {0!s}booze values (?)'.format(self.table_prefix),
                     largs
                     )
             elif self.driver.paramstyle == 'numeric':
                 cur.executemany(
-                    'insert into %sbooze values (:1)' % self.table_prefix,
+                    'insert into {0!s}booze values (:1)'.format(self.table_prefix),
                     largs
                     )
             elif self.driver.paramstyle == 'named':
                 cur.executemany(
-                    'insert into %sbooze values (:beer)' % self.table_prefix,
+                    'insert into {0!s}booze values (:beer)'.format(self.table_prefix),
                     margs
                     )
             elif self.driver.paramstyle == 'format':
                 cur.executemany(
-                    'insert into %sbooze values (%%s)' % self.table_prefix,
+                    'insert into {0!s}booze values (%s)'.format(self.table_prefix),
                     largs
                     )
             elif self.driver.paramstyle == 'pyformat':
                 cur.executemany(
-                    'insert into %sbooze values (%%(beer)s)' % (
+                    'insert into {0!s}booze values (%(beer)s)'.format((
                         self.table_prefix
-                        ),
+                        )),
                     margs
                     )
             else:
@@ -460,7 +459,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'insert using cursor.executemany set cursor.rowcount to '
                 'incorrect value %r' % cur.rowcount
                 )
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             res = cur.fetchall()
             self.assertEqual(len(res),2,
                 'cursor.fetchall retrieved incorrect number of rows'
@@ -486,7 +485,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             self.executeDDL1(cur)
             self.assertRaises(self.driver.Error,cur.fetchone)
 
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             self.assertEqual(cur.fetchone(),None,
                 'cursor.fetchone should return None if a query retrieves '
                 'no rows'
@@ -495,12 +494,12 @@ class DatabaseAPI20Test(unittest.TestCase):
 
             # cursor.fetchone should raise an Error if called after
             # executing a query that cannnot return rows
-            cur.execute("insert into %sbooze values ('Victoria Bitter')" % (
+            cur.execute("insert into {0!s}booze values ('Victoria Bitter')".format((
                 self.table_prefix
-                ))
+                )))
             self.assertRaises(self.driver.Error,cur.fetchone)
 
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             r = cur.fetchone()
             self.assertEqual(len(r),1,
                 'cursor.fetchone should have retrieved a single row'
@@ -529,7 +528,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             tests.
         '''
         populate = [
-            "insert into %sbooze values ('%s')" % (self.table_prefix,s) 
+            "insert into {0!s}booze values ('{1!s}')".format(self.table_prefix, s) 
                 for s in self.samples
             ]
         return populate
@@ -547,7 +546,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             for sql in self._populate():
                 cur.execute(sql)
 
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             r = cur.fetchmany()
             self.assertEqual(len(r),1,
                 'cursor.fetchmany retrieved incorrect number of rows, '
@@ -571,7 +570,7 @@ class DatabaseAPI20Test(unittest.TestCase):
 
             # Same as above, using cursor.arraysize
             cur.arraysize=4
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             r = cur.fetchmany() # Should get 4 rows
             self.assertEqual(len(r),4,
                 'cursor.arraysize not being honoured by fetchmany'
@@ -583,7 +582,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             self.failUnless(cur.rowcount in (-1,6))
 
             cur.arraysize=6
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             rows = cur.fetchmany() # Should get all rows
             self.failUnless(cur.rowcount in (-1,6))
             self.assertEqual(len(rows),6)
@@ -605,7 +604,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             self.failUnless(cur.rowcount in (-1,6))
 
             self.executeDDL2(cur)
-            cur.execute('select name from %sbarflys' % self.table_prefix)
+            cur.execute('select name from {0!s}barflys'.format(self.table_prefix))
             r = cur.fetchmany() # Should get empty sequence
             self.assertEqual(len(r),0,
                 'cursor.fetchmany should return an empty sequence if '
@@ -633,7 +632,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             # after executing a a statement that cannot return rows
             self.assertRaises(self.driver.Error,cur.fetchall)
 
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             rows = cur.fetchall()
             self.failUnless(cur.rowcount in (-1,len(self.samples)))
             self.assertEqual(len(rows),len(self.samples),
@@ -654,7 +653,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             self.failUnless(cur.rowcount in (-1,len(self.samples)))
 
             self.executeDDL2(cur)
-            cur.execute('select name from %sbarflys' % self.table_prefix)
+            cur.execute('select name from {0!s}barflys'.format(self.table_prefix))
             rows = cur.fetchall()
             self.failUnless(cur.rowcount in (-1,0))
             self.assertEqual(len(rows),0,
@@ -673,7 +672,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             for sql in self._populate():
                 cur.execute(sql)
 
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             rows1  = cur.fetchone()
             rows23 = cur.fetchmany(2)
             rows4  = cur.fetchone()
@@ -790,8 +789,8 @@ class DatabaseAPI20Test(unittest.TestCase):
         try:
             cur = con.cursor()
             self.executeDDL1(cur)
-            cur.execute('insert into %sbooze values (NULL)' % self.table_prefix)
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('insert into {0!s}booze values (NULL)'.format(self.table_prefix))
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             r = cur.fetchall()
             self.assertEqual(len(r),1)
             self.assertEqual(len(r[0]),1)

--- a/tests2/exceltests.py
+++ b/tests2/exceltests.py
@@ -22,7 +22,7 @@ class ExcelTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -80,7 +80,7 @@ class ExcelTestCase(unittest.TestCase):
     def test_tables(self):
         # This is useful for figuring out what is available
         tables = [ row.table_name for row in self.cursor.tables() ]
-        assert 'Sheet2$' in tables, 'tables: %s' % ' '.join(tables)
+        assert 'Sheet2$' in tables, 'tables: {0!s}'.format(' '.join(tables))
 
 
     # def test_append(self):
@@ -120,7 +120,7 @@ def main():
     path = dirname(abspath(__file__))
     filename = join(path, 'test.xls')
     assert os.path.exists(filename)
-    CNXNSTRING = 'Driver={Microsoft Excel Driver (*.xls)};DBQ=%s;READONLY=FALSE' % filename
+    CNXNSTRING = 'Driver={{Microsoft Excel Driver (*.xls)}};DBQ={0!s};READONLY=FALSE'.format(filename)
 
     cnxn = pyodbc.connect(CNXNSTRING, autocommit=True)
     print_library_info(cnxn)

--- a/tests2/freetdstests.py
+++ b/tests2/freetdstests.py
@@ -70,14 +70,14 @@ class FreeTDSTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
 
         for i in range(3):
             try:
-                self.cursor.execute("drop procedure proc%d" % i)
+                self.cursor.execute("drop procedure proc{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -186,9 +186,9 @@ class FreeTDSTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         if resulttype is None:
             resulttype = type(value)
@@ -219,9 +219,9 @@ class FreeTDSTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         if resulttype is None:
             resulttype = type(value)
@@ -255,7 +255,7 @@ class FreeTDSTestCase(unittest.TestCase):
             self._test_strtype('varchar', value, colsize=len(value))
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_varchar_%s' % len(value)] = _maketest(value)
+        locals()['test_varchar_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_varchar_many(self):
         self.cursor.execute("create table t1(c1 varchar(300), c2 varchar(300), c3 varchar(300))")
@@ -287,7 +287,7 @@ class FreeTDSTestCase(unittest.TestCase):
             self._test_strtype('nvarchar', value, colsize=len(value))
         return t
     for value in UNICODE_FENCEPOSTS:
-        locals()['test_unicode_%s' % len(value)] = _maketest(value)
+        locals()['test_unicode_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_unicode_upperlatin(self):
         self._test_strtype('nvarchar', u'á')
@@ -322,7 +322,7 @@ class FreeTDSTestCase(unittest.TestCase):
             self._test_strtype('varbinary', buffer(value), resulttype=pyodbc.BINARY, colsize=len(value))
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_binary_buffer_%s' % len(value)] = _maketest(value)
+        locals()['test_binary_buffer_{0!s}'.format(len(value))] = _maketest(value)
 
     # bytearray
 
@@ -332,7 +332,7 @@ class FreeTDSTestCase(unittest.TestCase):
                 self._test_strtype('varbinary', bytearray(value), colsize=len(value))
             return t
         for value in ANSI_FENCEPOSTS:
-            locals()['test_binary_bytearray_%s' % len(value)] = _maketest(value)
+            locals()['test_binary_bytearray_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # image
@@ -347,7 +347,7 @@ class FreeTDSTestCase(unittest.TestCase):
             self._test_strliketype('image', buffer(value), pyodbc.BINARY)
         return t
     for value in IMAGE_FENCEPOSTS:
-        locals()['test_image_buffer_%s' % len(value)] = _maketest(value)
+        locals()['test_image_buffer_{0!s}'.format(len(value))] = _maketest(value)
 
     if sys.hexversion >= 0x02060000:
         # Python 2.6+ supports bytearray, which pyodbc considers varbinary.
@@ -358,7 +358,7 @@ class FreeTDSTestCase(unittest.TestCase):
                 self._test_strtype('image', bytearray(value))
             return t
         for value in IMAGE_FENCEPOSTS:
-            locals()['test_image_bytearray_%s' % len(value)] = _maketest(value)
+            locals()['test_image_bytearray_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_image_upperlatin(self):
         self._test_strliketype('image', buffer('á'), pyodbc.BINARY)
@@ -379,7 +379,7 @@ class FreeTDSTestCase(unittest.TestCase):
             self._test_strliketype('text', value)
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_text_buffer_%s' % len(value)] = _maketest(value)
+        locals()['test_text_buffer_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_text_upperlatin(self):
         self._test_strliketype('text', 'á')
@@ -403,7 +403,7 @@ class FreeTDSTestCase(unittest.TestCase):
     def _decimal(self, precision, scale, negative):
         # From test provided by planders (thanks!) in Issue 91
 
-        self.cursor.execute("create table t1(d decimal(%s, %s))" % (precision, scale))
+        self.cursor.execute("create table t1(d decimal({0!s}, {1!s}))".format(precision, scale))
 
         # Construct a decimal that uses the maximum precision and scale.
         decStr = '9' * (precision - scale)
@@ -434,7 +434,7 @@ class FreeTDSTestCase(unittest.TestCase):
                        (38, 0,  True),
                        (38, 10, True),
                        (38, 38, True) ]:
-        locals()['test_decimal_%s_%s_%s' % (p, s, n and 'n' or 'p')] = _maketest(p, s, n)
+        locals()['test_decimal_{0!s}_{1!s}_{2!s}'.format(p, s, n and 'n' or 'p')] = _maketest(p, s, n)
 
 
     def test_decimal_e(self):
@@ -938,7 +938,7 @@ class FreeTDSTestCase(unittest.TestCase):
         # Create a table (t1) with 3 rows and a view (t2) into it.
         self.cursor.execute("create table t1(c1 int identity(1, 1), c2 varchar(50))")
         for i in range(3):
-            self.cursor.execute("insert into t1(c2) values (?)", "string%s" % i)
+            self.cursor.execute("insert into t1(c2) values (?)", "string{0!s}".format(i))
         self.cursor.execute("create view t2 as select * from t1")
 
         # Select from the view

--- a/tests2/informixtests.py
+++ b/tests2/informixtests.py
@@ -63,14 +63,14 @@ class InformixTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
 
         for i in range(3):
             try:
-                self.cursor.execute("drop procedure proc%d" % i)
+                self.cursor.execute("drop procedure proc{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -172,9 +172,9 @@ class InformixTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         self.cursor.execute(sql)
         self.cursor.execute("insert into t1 values(?)", value)
@@ -206,9 +206,9 @@ class InformixTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         self.cursor.execute(sql)
         self.cursor.execute("insert into t1 values(?)", value)
@@ -234,7 +234,7 @@ class InformixTestCase(unittest.TestCase):
             self._test_strtype('varchar', value, len(value))
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_varchar_%s' % len(value)] = _maketest(value)
+        locals()['test_varchar_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_varchar_many(self):
         self.cursor.execute("create table t1(c1 varchar(300), c2 varchar(300), c3 varchar(300))")
@@ -266,7 +266,7 @@ class InformixTestCase(unittest.TestCase):
             self._test_strtype('nvarchar', value, len(value))
         return t
     for value in UNICODE_FENCEPOSTS:
-        locals()['test_unicode_%s' % len(value)] = _maketest(value)
+        locals()['test_unicode_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_unicode_upperlatin(self):
         self._test_strtype('varchar', 'á')
@@ -288,7 +288,7 @@ class InformixTestCase(unittest.TestCase):
             self._test_strtype('varbinary', buffer(value), len(value))
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_binary_%s' % len(value)] = _maketest(value)
+        locals()['test_binary_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # image
@@ -303,7 +303,7 @@ class InformixTestCase(unittest.TestCase):
             self._test_strliketype('image', buffer(value))
         return t
     for value in IMAGE_FENCEPOSTS:
-        locals()['test_image_%s' % len(value)] = _maketest(value)
+        locals()['test_image_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_image_upperlatin(self):
         self._test_strliketype('image', buffer('á'))
@@ -324,7 +324,7 @@ class InformixTestCase(unittest.TestCase):
             self._test_strliketype('text', value)
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_text_%s' % len(value)] = _maketest(value)
+        locals()['test_text_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_text_upperlatin(self):
         self._test_strliketype('text', 'á')
@@ -348,7 +348,7 @@ class InformixTestCase(unittest.TestCase):
     def _decimal(self, precision, scale, negative):
         # From test provided by planders (thanks!) in Issue 91
 
-        self.cursor.execute("create table t1(d decimal(%s, %s))" % (precision, scale))
+        self.cursor.execute("create table t1(d decimal({0!s}, {1!s}))".format(precision, scale))
 
         # Construct a decimal that uses the maximum precision and scale.
         decStr = '9' * (precision - scale)
@@ -379,7 +379,7 @@ class InformixTestCase(unittest.TestCase):
                        (38, 0,  True),
                        (38, 10, True),
                        (38, 38, True) ]:
-        locals()['test_decimal_%s_%s_%s' % (p, s, n and 'n' or 'p')] = _maketest(p, s, n)
+        locals()['test_decimal_{0!s}_{1!s}_{2!s}'.format(p, s, n and 'n' or 'p')] = _maketest(p, s, n)
 
 
     def test_decimal_e(self):
@@ -926,7 +926,7 @@ class InformixTestCase(unittest.TestCase):
         # Create a table (t1) with 3 rows and a view (t2) into it.
         self.cursor.execute("create table t1(c1 int identity(1, 1), c2 varchar(50))")
         for i in range(3):
-            self.cursor.execute("insert into t1(c2) values (?)", "string%s" % i)
+            self.cursor.execute("insert into t1(c2) values (?)", "string{0!s}".format(i))
         self.cursor.execute("create view t2 as select * from t1")
 
         # Select from the view

--- a/tests2/mysqltests.py
+++ b/tests2/mysqltests.py
@@ -67,14 +67,14 @@ class MySqlTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
 
         for i in range(3):
             try:
-                self.cursor.execute("drop procedure proc%d" % i)
+                self.cursor.execute("drop procedure proc{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -133,9 +133,9 @@ class MySqlTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         try:
             self.cursor.execute(sql)
@@ -192,11 +192,11 @@ class MySqlTestCase(unittest.TestCase):
             self._test_strtype('varchar', value, max(1, len(value)))
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_varchar_%s' % len(value)] = _maketest(value)
+        locals()['test_varchar_{0!s}'.format(len(value))] = _maketest(value)
 
     # Generate a test using Unicode.
     for value in UNICODE_FENCEPOSTS:
-        locals()['test_wvarchar_%s' % len(value)] = _maketest(value)
+        locals()['test_wvarchar_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_varchar_many(self):
         self.cursor.execute("create table t1(c1 varchar(300), c2 varchar(300), c3 varchar(300))")
@@ -232,7 +232,7 @@ class MySqlTestCase(unittest.TestCase):
             self._test_strtype('varbinary', bytearray(value), max(1, len(value)))
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_binary_%s' % len(value)] = _maketest(value)
+        locals()['test_binary_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # blob
@@ -247,7 +247,7 @@ class MySqlTestCase(unittest.TestCase):
             self._test_strtype('blob', bytearray(value))
         return t
     for value in BLOB_FENCEPOSTS:
-        locals()['test_blob_%s' % len(value)] = _maketest(value)
+        locals()['test_blob_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_blob_upperlatin(self):
         self._test_strtype('blob', bytearray('á'))
@@ -265,7 +265,7 @@ class MySqlTestCase(unittest.TestCase):
             self._test_strtype('text', value)
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_text_%s' % len(value)] = _maketest(value)
+        locals()['test_text_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_text_upperlatin(self):
         self._test_strtype('text', u'á')

--- a/tests2/pgtests.py
+++ b/tests2/pgtests.py
@@ -63,7 +63,7 @@ class PGTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -115,9 +115,9 @@ class PGTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         self.cursor.execute(sql)
         self.cursor.execute("insert into t1 values(?)", value)
@@ -510,7 +510,7 @@ def main():
     if options.test:
         # Run a single test
         if not options.test.startswith('test_'):
-            options.test = 'test_%s' % (options.test)
+            options.test = 'test_{0!s}'.format((options.test))
 
         s = unittest.TestSuite([ PGTestCase(connection_string, options.ansi, options.unicode, options.test) ])
     else:

--- a/tests2/sqlitetests.py
+++ b/tests2/sqlitetests.py
@@ -75,7 +75,7 @@ class SqliteTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -144,9 +144,9 @@ class SqliteTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         self.cursor.execute(sql)
         self.cursor.execute("insert into t1 values(?)", value)
@@ -178,9 +178,9 @@ class SqliteTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         self.cursor.execute(sql)
         self.cursor.execute("insert into t1 values(?)", value)
@@ -205,7 +205,7 @@ class SqliteTestCase(unittest.TestCase):
             self._test_strtype('text', value, len(value))
         return t
     for value in UNICODE_FENCEPOSTS:
-        locals()['test_text_%s' % len(value)] = _maketest(value)
+        locals()['test_text_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_text_upperlatin(self):
         self._test_strtype('varchar', u'á')
@@ -227,7 +227,7 @@ class SqliteTestCase(unittest.TestCase):
             self._test_strtype('blob', buffer(value), len(value))
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_blob_%s' % len(value)] = _maketest(value)
+        locals()['test_blob_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_subquery_params(self):
         """Ensure parameter markers work in a subquery"""
@@ -538,7 +538,7 @@ class SqliteTestCase(unittest.TestCase):
         # Create a table (t1) with 3 rows and a view (t2) into it.
         self.cursor.execute("create table t1(c1 int identity(1, 1), c2 varchar(50))")
         for i in range(3):
-            self.cursor.execute("insert into t1(c2) values (?)", "string%s" % i)
+            self.cursor.execute("insert into t1(c2) values (?)", "string{0!s}".format(i))
         self.cursor.execute("create view t2 as select * from t1")
 
         # Select from the view

--- a/tests2/sqlservertests.py
+++ b/tests2/sqlservertests.py
@@ -86,14 +86,14 @@ class SqlServerTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
 
         for i in range(3):
             try:
-                self.cursor.execute("drop procedure proc%d" % i)
+                self.cursor.execute("drop procedure proc{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -208,9 +208,9 @@ class SqlServerTestCase(unittest.TestCase):
         assert colsize in (None, 'max') or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         if resulttype is None:
             resulttype = type(value)
@@ -237,9 +237,9 @@ class SqlServerTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         if resulttype is None:
             resulttype = type(value)
@@ -270,7 +270,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strtype('varchar', value, colsize=len(value))
         return t
     for value in UNICODE_SMALL_FENCEPOSTS:
-        locals()['test_varchar_%s' % len(value)] = _maketest(value)
+        locals()['test_varchar_{0!s}'.format(len(value))] = _maketest(value)
 
     # Also test varchar(max)
     def _maketest(value):
@@ -278,7 +278,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strtype('varchar', value, colsize='max')
         return t
     for value in UNICODE_MAX_FENCEPOSTS:
-        locals()['test_varcharmax_%s' % len(value)] = _maketest(value)
+        locals()['test_varcharmax_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_varchar_many(self):
         self.cursor.execute("create table t1(c1 varchar(300), c2 varchar(300), c3 varchar(300))")
@@ -310,7 +310,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strtype('nvarchar', value, colsize=len(value))
         return t
     for value in UNICODE_SMALL_FENCEPOSTS:
-        locals()['test_nvarchar_%s' % len(value)] = _maketest(value)
+        locals()['test_nvarchar_{0!s}'.format(len(value))] = _maketest(value)
 
     # Also test nvarchar(max)
     def _maketest(value):
@@ -318,7 +318,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strtype('nvarchar', value, colsize='max')
         return t
     for value in UNICODE_MAX_FENCEPOSTS:
-        locals()['test_nvarcharmax_%s' % len(value)] = _maketest(value)
+        locals()['test_nvarcharmax_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_unicode_upperlatin(self):
         self._test_strtype('nvarchar', u'\u00e5', colsize=1)
@@ -353,7 +353,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strtype('varbinary', buffer(value), resulttype=pyodbc.BINARY, colsize=len(value))
         return t
     for value in ANSI_SMALL_FENCEPOSTS:
-        locals()['test_binary_buffer_%s' % len(value)] = _maketest(value)
+        locals()['test_binary_buffer_{0!s}'.format(len(value))] = _maketest(value)
 
     # bytearray
 
@@ -363,7 +363,7 @@ class SqlServerTestCase(unittest.TestCase):
                 self._test_strtype('varbinary', bytearray(value), colsize=len(value))
             return t
         for value in ANSI_SMALL_FENCEPOSTS:
-            locals()['test_binary_bytearray_%s' % len(value)] = _maketest(value)
+            locals()['test_binary_bytearray_{0!s}'.format(len(value))] = _maketest(value)
 
     # varbinary(max)
     def _maketest(value):
@@ -371,7 +371,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strtype('varbinary', buffer(value), resulttype=pyodbc.BINARY, colsize='max')
         return t
     for value in ANSI_MAX_FENCEPOSTS:
-        locals()['test_binarymax_buffer_%s' % len(value)] = _maketest(value)
+        locals()['test_binarymax_buffer_{0!s}'.format(len(value))] = _maketest(value)
 
     # bytearray
 
@@ -381,7 +381,7 @@ class SqlServerTestCase(unittest.TestCase):
                 self._test_strtype('varbinary', bytearray(value), colsize='max')
             return t
         for value in ANSI_MAX_FENCEPOSTS:
-            locals()['test_binarymax_bytearray_%s' % len(value)] = _maketest(value)
+            locals()['test_binarymax_bytearray_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # image
@@ -396,7 +396,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strliketype('image', buffer(value), pyodbc.BINARY)
         return t
     for value in ANSI_LARGE_FENCEPOSTS:
-        locals()['test_image_buffer_%s' % len(value)] = _maketest(value)
+        locals()['test_image_buffer_{0!s}'.format(len(value))] = _maketest(value)
 
     if sys.hexversion >= 0x02060000:
         # Python 2.6+ supports bytearray, which pyodbc considers varbinary.
@@ -407,7 +407,7 @@ class SqlServerTestCase(unittest.TestCase):
                 self._test_strtype('image', bytearray(value))
             return t
         for value in ANSI_LARGE_FENCEPOSTS:
-            locals()['test_image_bytearray_%s' % len(value)] = _maketest(value)
+            locals()['test_image_bytearray_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_image_upperlatin(self):
         self._test_strliketype('image', buffer('á'), pyodbc.BINARY)
@@ -428,7 +428,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strliketype('text', value)
         return t
     for value in UNICODE_SMALL_FENCEPOSTS:
-        locals()['test_text_buffer_%s' % len(value)] = _maketest(value)
+        locals()['test_text_buffer_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_text_upperlatin(self):
         self._test_strliketype('text', u'á')
@@ -449,7 +449,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strliketype('xml', value)
         return t
     for value in UNICODE_SMALL_FENCEPOSTS:
-        locals()['test_xml_buffer_%s' % len(value)] = _maketest(value)
+        locals()['test_xml_buffer_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_xml_str(self):
         # SQL Server treats XML like *binary* data.
@@ -498,7 +498,7 @@ class SqlServerTestCase(unittest.TestCase):
     def _decimal(self, precision, scale, negative):
         # From test provided by planders (thanks!) in Issue 91
 
-        self.cursor.execute("create table t1(d decimal(%s, %s))" % (precision, scale))
+        self.cursor.execute("create table t1(d decimal({0!s}, {1!s}))".format(precision, scale))
 
         # Construct a decimal that uses the maximum precision and scale.
         decStr = '9' * (precision - scale)
@@ -529,7 +529,7 @@ class SqlServerTestCase(unittest.TestCase):
                        (38, 0,  True),
                        (38, 10, True),
                        (38, 38, True) ]:
-        locals()['test_decimal_%s_%s_%s' % (p, s, n and 'n' or 'p')] = _maketest(p, s, n)
+        locals()['test_decimal_{0!s}_{1!s}_{2!s}'.format(p, s, n and 'n' or 'p')] = _maketest(p, s, n)
 
 
     def test_decimal_e(self):
@@ -1110,7 +1110,7 @@ class SqlServerTestCase(unittest.TestCase):
         # Create a table (t1) with 3 rows and a view (t2) into it.
         self.cursor.execute("create table t1(c1 int identity(1, 1), c2 varchar(50))")
         for i in range(3):
-            self.cursor.execute("insert into t1(c2) values (?)", "string%s" % i)
+            self.cursor.execute("insert into t1(c2) values (?)", "string{0!s}".format(i))
         self.cursor.execute("create view t2 as select * from t1")
 
         # Select from the view

--- a/tests2/testutils.py
+++ b/tests2/testutils.py
@@ -16,11 +16,11 @@ def add_to_path():
     import imp
 
     library_exts  = [ t[0] for t in imp.get_suffixes() if t[-1] == imp.C_EXTENSION ]
-    library_names = [ 'pyodbc%s' % ext for ext in library_exts ]
+    library_names = [ 'pyodbc{0!s}'.format(ext) for ext in library_exts ]
 
     # Only go into directories that match our version number.
 
-    dir_suffix = '-%s.%s' % (sys.version_info[0], sys.version_info[1])
+    dir_suffix = '-{0!s}.{1!s}'.format(sys.version_info[0], sys.version_info[1])
 
     build = join(dirname(dirname(abspath(__file__))), 'build')
 
@@ -39,23 +39,23 @@ def add_to_path():
 
 def print_library_info(cnxn):
     import pyodbc
-    print('python:  %s' % sys.version)
-    print('pyodbc:  %s %s' % (pyodbc.version, os.path.abspath(pyodbc.__file__)))
-    print('odbc:    %s' % cnxn.getinfo(pyodbc.SQL_ODBC_VER))
-    print('driver:  %s %s' % (cnxn.getinfo(pyodbc.SQL_DRIVER_NAME), cnxn.getinfo(pyodbc.SQL_DRIVER_VER)))
-    print('         supports ODBC version %s' % cnxn.getinfo(pyodbc.SQL_DRIVER_ODBC_VER))
-    print('os:      %s' % platform.system())
-    print('unicode: Py_Unicode=%s SQLWCHAR=%s' % (pyodbc.UNICODE_SIZE, pyodbc.SQLWCHAR_SIZE))
+    print('python:  {0!s}'.format(sys.version))
+    print('pyodbc:  {0!s} {1!s}'.format(pyodbc.version, os.path.abspath(pyodbc.__file__)))
+    print('odbc:    {0!s}'.format(cnxn.getinfo(pyodbc.SQL_ODBC_VER)))
+    print('driver:  {0!s} {1!s}'.format(cnxn.getinfo(pyodbc.SQL_DRIVER_NAME), cnxn.getinfo(pyodbc.SQL_DRIVER_VER)))
+    print('         supports ODBC version {0!s}'.format(cnxn.getinfo(pyodbc.SQL_DRIVER_ODBC_VER)))
+    print('os:      {0!s}'.format(platform.system()))
+    print('unicode: Py_Unicode={0!s} SQLWCHAR={1!s}'.format(pyodbc.UNICODE_SIZE, pyodbc.SQLWCHAR_SIZE))
 
     cursor = cnxn.cursor()
     for typename in ['VARCHAR', 'WVARCHAR', 'BINARY']:
         t = getattr(pyodbc, 'SQL_' + typename)
         cursor.getTypeInfo(t)
         row = cursor.fetchone()
-        print('Max %s = %s' % (typename, row and row[2] or '(not supported)'))
+        print('Max {0!s} = {1!s}'.format(typename, row and row[2] or '(not supported)'))
 
     if platform.system() == 'Windows':
-        print('         %s' % ' '.join([s for s in platform.win32_ver() if s]))
+        print('         {0!s}'.format(' '.join([s for s in platform.win32_ver() if s])))
 
 
 def load_tests(testclass, name, *args):
@@ -70,7 +70,7 @@ def load_tests(testclass, name, *args):
     """
     if name:
         if not name.startswith('test_'):
-            name = 'test_%s' % name
+            name = 'test_{0!s}'.format(name)
         names = [ name ]
 
     else:
@@ -107,7 +107,7 @@ def load_setup_connection_string(section):
         p = SafeConfigParser()
         p.read(fqn)
     except:
-        raise SystemExit('Unable to parse %s: %s' % (path, sys.exc_info()[1]))
+        raise SystemExit('Unable to parse {0!s}: {1!s}'.format(path, sys.exc_info()[1]))
 
     if p.has_option(section, KEY):
         return p.get(section, KEY)

--- a/tests3/accesstests.py
+++ b/tests3/accesstests.py
@@ -79,7 +79,7 @@ class AccessTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -135,12 +135,12 @@ class AccessTestCase(unittest.TestCase):
         """
         The implementation for string, Unicode, and binary tests.
         """
-        assert colsize is None or (value is None or colsize >= len(value)), 'colsize=%s value=%s' % (colsize, (value is None) and 'none' or len(value))
+        assert colsize is None or (value is None or colsize >= len(value)), 'colsize={0!s} value={1!s}'.format(colsize, (value is None) and 'none' or len(value))
 
         if colsize:
-            sql = "create table t1(n1 int not null, s1 %s(%s), s2 %s(%s))" % (sqltype, colsize, sqltype, colsize)
+            sql = "create table t1(n1 int not null, s1 {0!s}({1!s}), s2 {2!s}({3!s}))".format(sqltype, colsize, sqltype, colsize)
         else:
-            sql = "create table t1(n1 int not null, s1 %s, s2 %s)" % (sqltype, sqltype)
+            sql = "create table t1(n1 int not null, s1 {0!s}, s2 {1!s})".format(sqltype, sqltype)
 
         self.cursor.execute(sql)
         self.cursor.execute("insert into t1 values(1, ?, ?)", (value, value))
@@ -172,10 +172,10 @@ class AccessTestCase(unittest.TestCase):
     def _maketest(value):
         def t(self):
             self._test_strtype('varchar', value, len(value))
-        t.__doc__ = 'unicode %s' % len(value)
+        t.__doc__ = 'unicode {0!s}'.format(len(value))
         return t
     for value in UNICODE_FENCEPOSTS:
-        locals()['test_unicode_%s' % len(value)] = _maketest(value)
+        locals()['test_unicode_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # ansi -> varchar
@@ -187,10 +187,10 @@ class AccessTestCase(unittest.TestCase):
     def _maketest(value):
         def t(self):
             self._test_strtype('varchar', value, len(value))
-        t.__doc__ = 'ansi %s' % len(value)
+        t.__doc__ = 'ansi {0!s}'.format(len(value))
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_ansivarchar_%s' % len(value)] = _maketest(value)
+        locals()['test_ansivarchar_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # binary
@@ -200,10 +200,10 @@ class AccessTestCase(unittest.TestCase):
     def _maketest(value):
         def t(self):
             self._test_strtype('varbinary', buffer(value), len(value))
-        t.__doc__ = 'binary %s' % len(value)
+        t.__doc__ = 'binary {0!s}'.format(len(value))
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_binary_%s' % len(value)] = _maketest(value)
+        locals()['test_binary_{0!s}'.format(len(value))] = _maketest(value)
 
 
     #
@@ -217,10 +217,10 @@ class AccessTestCase(unittest.TestCase):
     def _maketest(value):
         def t(self):
             self._test_strtype('image', buffer(value))
-        t.__doc__ = 'image %s' % len(value)
+        t.__doc__ = 'image {0!s}'.format(len(value))
         return t
     for value in IMAGE_FENCEPOSTS:
-        locals()['test_image_%s' % len(value)] = _maketest(value)
+        locals()['test_image_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # memo
@@ -233,19 +233,19 @@ class AccessTestCase(unittest.TestCase):
     def _maketest(value):
         def t(self):
             self._test_strtype('memo', unicode(value))
-        t.__doc__ = 'Unicode to memo %s' % len(value)
+        t.__doc__ = 'Unicode to memo {0!s}'.format(len(value))
         return t
     for value in IMAGE_FENCEPOSTS:
-        locals()['test_memo_%s' % len(value)] = _maketest(value)
+        locals()['test_memo_{0!s}'.format(len(value))] = _maketest(value)
 
     # ansi -> memo
     def _maketest(value):
         def t(self):
             self._test_strtype('memo', value)
-        t.__doc__ = 'ANSI to memo %s' % len(value)
+        t.__doc__ = 'ANSI to memo {0!s}'.format(len(value))
         return t
     for value in IMAGE_FENCEPOSTS:
-        locals()['test_ansimemo_%s' % len(value)] = _maketest(value)
+        locals()['test_ansimemo_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_subquery_params(self):
         """Ensure parameter markers work in a subquery"""
@@ -628,7 +628,7 @@ def main():
         driver = 'Microsoft Access Driver (*.mdb)'
 
     global CNXNSTRING
-    CNXNSTRING = 'DRIVER={%s};DBQ=%s;ExtendedAnsiSQL=1' % (driver, abspath(args[0]))
+    CNXNSTRING = 'DRIVER={{{0!s}}};DBQ={1!s};ExtendedAnsiSQL=1'.format(driver, abspath(args[0]))
 
     cnxn = pyodbc.connect(CNXNSTRING)
     print_library_info(cnxn)

--- a/tests3/dbapi20.py
+++ b/tests3/dbapi20.py
@@ -90,10 +90,10 @@ class DatabaseAPI20Test(unittest.TestCase):
     connect_kw_args = {} # Keyword arguments for connect
     table_prefix = 'dbapi20test_' # If you need to specify a prefix for tables
 
-    ddl1 = 'create table %sbooze (name varchar(20))' % table_prefix
-    ddl2 = 'create table %sbarflys (name varchar(20))' % table_prefix
-    xddl1 = 'drop table %sbooze' % table_prefix
-    xddl2 = 'drop table %sbarflys' % table_prefix
+    ddl1 = 'create table {0!s}booze (name varchar(20))'.format(table_prefix)
+    ddl2 = 'create table {0!s}barflys (name varchar(20))'.format(table_prefix)
+    xddl1 = 'drop table {0!s}booze'.format(table_prefix)
+    xddl2 = 'drop table {0!s}barflys'.format(table_prefix)
 
     lowerfunc = 'lower' # Name of stored procedure to convert string->lowercase
         
@@ -251,10 +251,10 @@ class DatabaseAPI20Test(unittest.TestCase):
             cur1 = con.cursor()
             cur2 = con.cursor()
             self.executeDDL1(cur1)
-            cur1.execute("insert into %sbooze values ('Victoria Bitter')" % (
+            cur1.execute("insert into {0!s}booze values ('Victoria Bitter')".format((
                 self.table_prefix
-                ))
-            cur2.execute("select name from %sbooze" % self.table_prefix)
+                )))
+            cur2.execute("select name from {0!s}booze".format(self.table_prefix))
             booze = cur2.fetchall()
             self.assertEqual(len(booze),1)
             self.assertEqual(len(booze[0]),1)
@@ -271,7 +271,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'cursor.description should be none after executing a '
                 'statement that can return no rows (such as DDL)'
                 )
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             self.assertEqual(len(cur.description),1,
                 'cursor.description describes too many columns'
                 )
@@ -282,8 +282,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'cursor.description[x][0] must return column name'
                 )
             self.assertEqual(cur.description[0][1],self.driver.STRING,
-                'cursor.description[x][1] must return column type. Got %r'
-                    % cur.description[0][1]
+                'cursor.description[x][1] must return column type. Got {0!r}'.format(cur.description[0][1])
                 )
 
             # Make sure self.description gets reset
@@ -304,14 +303,14 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'cursor.rowcount should be -1 after executing no-result '
                 'statements'
                 )
-            cur.execute("insert into %sbooze values ('Victoria Bitter')" % (
+            cur.execute("insert into {0!s}booze values ('Victoria Bitter')".format((
                 self.table_prefix
-                ))
+                )))
             self.failUnless(cur.rowcount in (-1,1),
                 'cursor.rowcount should == number or rows inserted, or '
                 'set to -1 after executing an insert statement'
                 )
-            cur.execute("select name from %sbooze" % self.table_prefix)
+            cur.execute("select name from {0!s}booze".format(self.table_prefix))
             self.failUnless(cur.rowcount in (-1,1),
                 'cursor.rowcount should == number of rows returned, or '
                 'set to -1 after executing a select statement'
@@ -372,41 +371,41 @@ class DatabaseAPI20Test(unittest.TestCase):
 
     def _paraminsert(self,cur):
         self.executeDDL1(cur)
-        cur.execute("insert into %sbooze values ('Victoria Bitter')" % (
+        cur.execute("insert into {0!s}booze values ('Victoria Bitter')".format((
             self.table_prefix
-            ))
+            )))
         self.failUnless(cur.rowcount in (-1,1))
 
         if self.driver.paramstyle == 'qmark':
             cur.execute(
-                'insert into %sbooze values (?)' % self.table_prefix,
+                'insert into {0!s}booze values (?)'.format(self.table_prefix),
                 ("Cooper's",)
                 )
         elif self.driver.paramstyle == 'numeric':
             cur.execute(
-                'insert into %sbooze values (:1)' % self.table_prefix,
+                'insert into {0!s}booze values (:1)'.format(self.table_prefix),
                 ("Cooper's",)
                 )
         elif self.driver.paramstyle == 'named':
             cur.execute(
-                'insert into %sbooze values (:beer)' % self.table_prefix, 
+                'insert into {0!s}booze values (:beer)'.format(self.table_prefix), 
                 {'beer':"Cooper's"}
                 )
         elif self.driver.paramstyle == 'format':
             cur.execute(
-                'insert into %sbooze values (%%s)' % self.table_prefix,
+                'insert into {0!s}booze values (%s)'.format(self.table_prefix),
                 ("Cooper's",)
                 )
         elif self.driver.paramstyle == 'pyformat':
             cur.execute(
-                'insert into %sbooze values (%%(beer)s)' % self.table_prefix,
+                'insert into {0!s}booze values (%(beer)s)'.format(self.table_prefix),
                 {'beer':"Cooper's"}
                 )
         else:
             self.fail('Invalid paramstyle')
         self.failUnless(cur.rowcount in (-1,1))
 
-        cur.execute('select name from %sbooze' % self.table_prefix)
+        cur.execute('select name from {0!s}booze'.format(self.table_prefix))
         res = cur.fetchall()
         self.assertEqual(len(res),2,'cursor.fetchall returned too few rows')
         beers = [res[0][0],res[1][0]]
@@ -429,29 +428,29 @@ class DatabaseAPI20Test(unittest.TestCase):
             margs = [ {'beer': "Cooper's"}, {'beer': "Boag's"} ]
             if self.driver.paramstyle == 'qmark':
                 cur.executemany(
-                    'insert into %sbooze values (?)' % self.table_prefix,
+                    'insert into {0!s}booze values (?)'.format(self.table_prefix),
                     largs
                     )
             elif self.driver.paramstyle == 'numeric':
                 cur.executemany(
-                    'insert into %sbooze values (:1)' % self.table_prefix,
+                    'insert into {0!s}booze values (:1)'.format(self.table_prefix),
                     largs
                     )
             elif self.driver.paramstyle == 'named':
                 cur.executemany(
-                    'insert into %sbooze values (:beer)' % self.table_prefix,
+                    'insert into {0!s}booze values (:beer)'.format(self.table_prefix),
                     margs
                     )
             elif self.driver.paramstyle == 'format':
                 cur.executemany(
-                    'insert into %sbooze values (%%s)' % self.table_prefix,
+                    'insert into {0!s}booze values (%s)'.format(self.table_prefix),
                     largs
                     )
             elif self.driver.paramstyle == 'pyformat':
                 cur.executemany(
-                    'insert into %sbooze values (%%(beer)s)' % (
+                    'insert into {0!s}booze values (%(beer)s)'.format((
                         self.table_prefix
-                        ),
+                        )),
                     margs
                     )
             else:
@@ -460,7 +459,7 @@ class DatabaseAPI20Test(unittest.TestCase):
                 'insert using cursor.executemany set cursor.rowcount to '
                 'incorrect value %r' % cur.rowcount
                 )
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             res = cur.fetchall()
             self.assertEqual(len(res),2,
                 'cursor.fetchall retrieved incorrect number of rows'
@@ -486,7 +485,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             self.executeDDL1(cur)
             self.assertRaises(self.driver.Error,cur.fetchone)
 
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             self.assertEqual(cur.fetchone(),None,
                 'cursor.fetchone should return None if a query retrieves '
                 'no rows'
@@ -495,12 +494,12 @@ class DatabaseAPI20Test(unittest.TestCase):
 
             # cursor.fetchone should raise an Error if called after
             # executing a query that cannnot return rows
-            cur.execute("insert into %sbooze values ('Victoria Bitter')" % (
+            cur.execute("insert into {0!s}booze values ('Victoria Bitter')".format((
                 self.table_prefix
-                ))
+                )))
             self.assertRaises(self.driver.Error,cur.fetchone)
 
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             r = cur.fetchone()
             self.assertEqual(len(r),1,
                 'cursor.fetchone should have retrieved a single row'
@@ -529,7 +528,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             tests.
         '''
         populate = [
-            "insert into %sbooze values ('%s')" % (self.table_prefix,s) 
+            "insert into {0!s}booze values ('{1!s}')".format(self.table_prefix, s) 
                 for s in self.samples
             ]
         return populate
@@ -547,7 +546,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             for sql in self._populate():
                 cur.execute(sql)
 
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             r = cur.fetchmany()
             self.assertEqual(len(r),1,
                 'cursor.fetchmany retrieved incorrect number of rows, '
@@ -571,7 +570,7 @@ class DatabaseAPI20Test(unittest.TestCase):
 
             # Same as above, using cursor.arraysize
             cur.arraysize=4
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             r = cur.fetchmany() # Should get 4 rows
             self.assertEqual(len(r),4,
                 'cursor.arraysize not being honoured by fetchmany'
@@ -583,7 +582,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             self.failUnless(cur.rowcount in (-1,6))
 
             cur.arraysize=6
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             rows = cur.fetchmany() # Should get all rows
             self.failUnless(cur.rowcount in (-1,6))
             self.assertEqual(len(rows),6)
@@ -605,7 +604,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             self.failUnless(cur.rowcount in (-1,6))
 
             self.executeDDL2(cur)
-            cur.execute('select name from %sbarflys' % self.table_prefix)
+            cur.execute('select name from {0!s}barflys'.format(self.table_prefix))
             r = cur.fetchmany() # Should get empty sequence
             self.assertEqual(len(r),0,
                 'cursor.fetchmany should return an empty sequence if '
@@ -633,7 +632,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             # after executing a a statement that cannot return rows
             self.assertRaises(self.driver.Error,cur.fetchall)
 
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             rows = cur.fetchall()
             self.failUnless(cur.rowcount in (-1,len(self.samples)))
             self.assertEqual(len(rows),len(self.samples),
@@ -654,7 +653,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             self.failUnless(cur.rowcount in (-1,len(self.samples)))
 
             self.executeDDL2(cur)
-            cur.execute('select name from %sbarflys' % self.table_prefix)
+            cur.execute('select name from {0!s}barflys'.format(self.table_prefix))
             rows = cur.fetchall()
             self.failUnless(cur.rowcount in (-1,0))
             self.assertEqual(len(rows),0,
@@ -673,7 +672,7 @@ class DatabaseAPI20Test(unittest.TestCase):
             for sql in self._populate():
                 cur.execute(sql)
 
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             rows1  = cur.fetchone()
             rows23 = cur.fetchmany(2)
             rows4  = cur.fetchone()
@@ -790,8 +789,8 @@ class DatabaseAPI20Test(unittest.TestCase):
         try:
             cur = con.cursor()
             self.executeDDL1(cur)
-            cur.execute('insert into %sbooze values (NULL)' % self.table_prefix)
-            cur.execute('select name from %sbooze' % self.table_prefix)
+            cur.execute('insert into {0!s}booze values (NULL)'.format(self.table_prefix))
+            cur.execute('select name from {0!s}booze'.format(self.table_prefix))
             r = cur.fetchall()
             self.assertEqual(len(r),1)
             self.assertEqual(len(r[0]),1)

--- a/tests3/exceltests.py
+++ b/tests3/exceltests.py
@@ -22,7 +22,7 @@ class ExcelTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -80,7 +80,7 @@ class ExcelTestCase(unittest.TestCase):
     def test_tables(self):
         # This is useful for figuring out what is available
         tables = [ row.table_name for row in self.cursor.tables() ]
-        assert 'Sheet2$' in tables, 'tables: %s' % ' '.join(tables)
+        assert 'Sheet2$' in tables, 'tables: {0!s}'.format(' '.join(tables))
 
 
     # def test_append(self):
@@ -120,7 +120,7 @@ def main():
     path = dirname(abspath(__file__))
     filename = join(path, 'test.xls')
     assert os.path.exists(filename)
-    CNXNSTRING = 'Driver={Microsoft Excel Driver (*.xls)};DBQ=%s;READONLY=FALSE' % filename
+    CNXNSTRING = 'Driver={{Microsoft Excel Driver (*.xls)}};DBQ={0!s};READONLY=FALSE'.format(filename)
 
     cnxn = pyodbc.connect(CNXNSTRING, autocommit=True)
     print_library_info(cnxn)

--- a/tests3/informixtests.py
+++ b/tests3/informixtests.py
@@ -63,14 +63,14 @@ class InformixTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
 
         for i in range(3):
             try:
-                self.cursor.execute("drop procedure proc%d" % i)
+                self.cursor.execute("drop procedure proc{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -172,9 +172,9 @@ class InformixTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         self.cursor.execute(sql)
         self.cursor.execute("insert into t1 values(?)", value)
@@ -206,9 +206,9 @@ class InformixTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         self.cursor.execute(sql)
         self.cursor.execute("insert into t1 values(?)", value)
@@ -234,7 +234,7 @@ class InformixTestCase(unittest.TestCase):
             self._test_strtype('varchar', value, len(value))
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_varchar_%s' % len(value)] = _maketest(value)
+        locals()['test_varchar_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_varchar_many(self):
         self.cursor.execute("create table t1(c1 varchar(300), c2 varchar(300), c3 varchar(300))")
@@ -266,7 +266,7 @@ class InformixTestCase(unittest.TestCase):
             self._test_strtype('nvarchar', value, len(value))
         return t
     for value in UNICODE_FENCEPOSTS:
-        locals()['test_unicode_%s' % len(value)] = _maketest(value)
+        locals()['test_unicode_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_unicode_upperlatin(self):
         self._test_strtype('varchar', 'á')
@@ -288,7 +288,7 @@ class InformixTestCase(unittest.TestCase):
             self._test_strtype('varbinary', buffer(value), len(value))
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_binary_%s' % len(value)] = _maketest(value)
+        locals()['test_binary_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # image
@@ -303,7 +303,7 @@ class InformixTestCase(unittest.TestCase):
             self._test_strliketype('image', buffer(value))
         return t
     for value in IMAGE_FENCEPOSTS:
-        locals()['test_image_%s' % len(value)] = _maketest(value)
+        locals()['test_image_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_image_upperlatin(self):
         self._test_strliketype('image', buffer('á'))
@@ -324,7 +324,7 @@ class InformixTestCase(unittest.TestCase):
             self._test_strliketype('text', value)
         return t
     for value in ANSI_FENCEPOSTS:
-        locals()['test_text_%s' % len(value)] = _maketest(value)
+        locals()['test_text_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_text_upperlatin(self):
         self._test_strliketype('text', 'á')
@@ -348,7 +348,7 @@ class InformixTestCase(unittest.TestCase):
     def _decimal(self, precision, scale, negative):
         # From test provided by planders (thanks!) in Issue 91
 
-        self.cursor.execute("create table t1(d decimal(%s, %s))" % (precision, scale))
+        self.cursor.execute("create table t1(d decimal({0!s}, {1!s}))".format(precision, scale))
 
         # Construct a decimal that uses the maximum precision and scale.
         decStr = '9' * (precision - scale)
@@ -379,7 +379,7 @@ class InformixTestCase(unittest.TestCase):
                        (38, 0,  True),
                        (38, 10, True),
                        (38, 38, True) ]:
-        locals()['test_decimal_%s_%s_%s' % (p, s, n and 'n' or 'p')] = _maketest(p, s, n)
+        locals()['test_decimal_{0!s}_{1!s}_{2!s}'.format(p, s, n and 'n' or 'p')] = _maketest(p, s, n)
 
 
     def test_decimal_e(self):
@@ -926,7 +926,7 @@ class InformixTestCase(unittest.TestCase):
         # Create a table (t1) with 3 rows and a view (t2) into it.
         self.cursor.execute("create table t1(c1 int identity(1, 1), c2 varchar(50))")
         for i in range(3):
-            self.cursor.execute("insert into t1(c2) values (?)", "string%s" % i)
+            self.cursor.execute("insert into t1(c2) values (?)", "string{0!s}".format(i))
         self.cursor.execute("create view t2 as select * from t1")
 
         # Select from the view

--- a/tests3/mysqltests.py
+++ b/tests3/mysqltests.py
@@ -68,14 +68,14 @@ class MySqlTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
 
         for i in range(3):
             try:
-                self.cursor.execute("drop procedure proc%d" % i)
+                self.cursor.execute("drop procedure proc{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -134,9 +134,9 @@ class MySqlTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         try:
             self.cursor.execute(sql)
@@ -168,7 +168,7 @@ class MySqlTestCase(unittest.TestCase):
             self._test_strtype('varchar', value, max(1, len(value)))
         return t
     for value in STR_FENCEPOSTS:
-        locals()['test_varchar_%s' % len(value)] = _maketest(value)
+        locals()['test_varchar_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_varchar_many(self):
         self.cursor.execute("create table t1(c1 varchar(300), c2 varchar(300), c3 varchar(300))")
@@ -213,7 +213,7 @@ class MySqlTestCase(unittest.TestCase):
             self._test_strtype('varbinary', bytes(value, 'utf-8'), max(1, len(value)))
         return t
     for value in STR_FENCEPOSTS:
-        locals()['test_binary_%s' % len(value)] = _maketest(value)
+        locals()['test_binary_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # blob
@@ -228,7 +228,7 @@ class MySqlTestCase(unittest.TestCase):
             self._test_strtype('blob', bytes(value, 'utf-8'))
         return t
     for value in BLOB_FENCEPOSTS:
-        locals()['test_blob_%s' % len(value)] = _maketest(value)
+        locals()['test_blob_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_blob_upperlatin(self):
         self._test_strtype('blob', bytes('á', 'utf-8'))
@@ -246,7 +246,7 @@ class MySqlTestCase(unittest.TestCase):
             self._test_strtype('text', value)
         return t
     for value in STR_FENCEPOSTS:
-        locals()['test_text_%s' % len(value)] = _maketest(value)
+        locals()['test_text_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_text_upperlatin(self):
         self._test_strtype('text', 'á')

--- a/tests3/pgtests.py
+++ b/tests3/pgtests.py
@@ -57,7 +57,7 @@ class PGTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -117,9 +117,9 @@ class PGTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         self.cursor.execute(sql)
         self.cursor.execute("insert into t1 values(?)", value)
@@ -471,7 +471,7 @@ def main():
     if options.test:
         # Run a single test
         if not options.test.startswith('test_'):
-            options.test = 'test_%s' % (options.test)
+            options.test = 'test_{0!s}'.format((options.test))
 
         s = unittest.TestSuite([ PGTestCase(connection_string, options.ansi, options.test) ])
     else:

--- a/tests3/sqlitetests.py
+++ b/tests3/sqlitetests.py
@@ -75,7 +75,7 @@ class SqliteTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -134,9 +134,9 @@ class SqliteTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         self.cursor.execute(sql)
         self.cursor.execute("insert into t1 values(?)", value)
@@ -168,9 +168,9 @@ class SqliteTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         self.cursor.execute(sql)
         self.cursor.execute("insert into t1 values(?)", value)
@@ -195,7 +195,7 @@ class SqliteTestCase(unittest.TestCase):
             self._test_strtype('text', value, len(value))
         return t
     for value in STR_FENCEPOSTS:
-        locals()['test_text_%s' % len(value)] = _maketest(value)
+        locals()['test_text_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_text_upperlatin(self):
         self._test_strtype('varchar', 'á')
@@ -217,7 +217,7 @@ class SqliteTestCase(unittest.TestCase):
             self._test_strtype('blob', bytearray(value), len(value))
         return t
     for value in BYTE_FENCEPOSTS:
-        locals()['test_blob_%s' % len(value)] = _maketest(value)
+        locals()['test_blob_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_subquery_params(self):
         """Ensure parameter markers work in a subquery"""
@@ -521,7 +521,7 @@ class SqliteTestCase(unittest.TestCase):
         # Create a table (t1) with 3 rows and a view (t2) into it.
         self.cursor.execute("create table t1(c1 int identity(1, 1), c2 varchar(50))")
         for i in range(3):
-            self.cursor.execute("insert into t1(c2) values (?)", "string%s" % i)
+            self.cursor.execute("insert into t1(c2) values (?)", "string{0!s}".format(i))
         self.cursor.execute("create view t2 as select * from t1")
 
         # Select from the view

--- a/tests3/sqlservertests.py
+++ b/tests3/sqlservertests.py
@@ -80,14 +80,14 @@ class SqlServerTestCase(unittest.TestCase):
 
         for i in range(3):
             try:
-                self.cursor.execute("drop table t%d" % i)
+                self.cursor.execute("drop table t{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
 
         for i in range(3):
             try:
-                self.cursor.execute("drop procedure proc%d" % i)
+                self.cursor.execute("drop procedure proc{0:d}".format(i))
                 self.cnxn.commit()
             except:
                 pass
@@ -196,9 +196,9 @@ class SqlServerTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         if resulttype is None:
             resulttype = type(value)
@@ -229,9 +229,9 @@ class SqlServerTestCase(unittest.TestCase):
         assert colsize is None or (value is None or colsize >= len(value))
 
         if colsize:
-            sql = "create table t1(s %s(%s))" % (sqltype, colsize)
+            sql = "create table t1(s {0!s}({1!s}))".format(sqltype, colsize)
         else:
-            sql = "create table t1(s %s)" % sqltype
+            sql = "create table t1(s {0!s})".format(sqltype)
 
         if resulttype is None:
             resulttype = type(value)
@@ -263,7 +263,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strtype('varchar', value, colsize=len(value))
         return t
     for value in STR_FENCEPOSTS:
-        locals()['test_varchar_%s' % len(value)] = _maketest(value)
+        locals()['test_varchar_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_varchar_many(self):
         self.cursor.execute("create table t1(c1 varchar(300), c2 varchar(300), c3 varchar(300))")
@@ -292,7 +292,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strtype('nvarchar', value, colsize=len(value))
         return t
     for value in STR_FENCEPOSTS:
-        locals()['test_unicode_%s' % len(value)] = _maketest(value)
+        locals()['test_unicode_{0!s}'.format(len(value))] = _maketest(value)
 
     def test_unicode_longmax(self):
         # Issue 188:	Segfault when fetching NVARCHAR(MAX) data over 511 bytes
@@ -316,7 +316,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strtype('varbinary', bytearray(value), colsize=len(value), resulttype=bytes)
         return t
     for value in BYTE_FENCEPOSTS:
-        locals()['test_binary_bytearray_%s' % len(value)] = _maketest(value)
+        locals()['test_binary_bytearray_{0!s}'.format(len(value))] = _maketest(value)
 
     # bytes
 
@@ -325,7 +325,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strtype('varbinary', bytes(value), colsize=len(value))
         return t
     for value in BYTE_FENCEPOSTS:
-        locals()['test_binary_bytes_%s' % len(value)] = _maketest(value)
+        locals()['test_binary_bytes_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # image
@@ -341,7 +341,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strliketype('image', bytearray(value), resulttype=bytes)
         return t
     for value in IMAGE_FENCEPOSTS:
-        locals()['test_image_bytearray_%s' % len(value)] = _maketest(value)
+        locals()['test_image_bytearray_{0!s}'.format(len(value))] = _maketest(value)
 
     # bytes
 
@@ -350,7 +350,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strliketype('image', bytes(value))
         return t
     for value in IMAGE_FENCEPOSTS:
-        locals()['test_image_bytes_%s' % len(value)] = _maketest(value)
+        locals()['test_image_bytes_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # text
@@ -364,7 +364,7 @@ class SqlServerTestCase(unittest.TestCase):
             self._test_strliketype('text', value)
         return t
     for value in STR_FENCEPOSTS:
-        locals()['test_text_%s' % len(value)] = _maketest(value)
+        locals()['test_text_{0!s}'.format(len(value))] = _maketest(value)
 
     #
     # bit
@@ -385,7 +385,7 @@ class SqlServerTestCase(unittest.TestCase):
     def _decimal(self, precision, scale, negative):
         # From test provided by planders (thanks!) in Issue 91
 
-        self.cursor.execute("create table t1(d decimal(%s, %s))" % (precision, scale))
+        self.cursor.execute("create table t1(d decimal({0!s}, {1!s}))".format(precision, scale))
 
         # Construct a decimal that uses the maximum precision and scale.
         decStr = '9' * (precision - scale)
@@ -417,7 +417,7 @@ class SqlServerTestCase(unittest.TestCase):
                        (38, 0,  True),
                        (38, 10, True),
                        (38, 38, True) ]:
-        locals()['test_decimal_%s_%s_%s' % (p, s, n and 'n' or 'p')] = _maketest(p, s, n)
+        locals()['test_decimal_{0!s}_{1!s}_{2!s}'.format(p, s, n and 'n' or 'p')] = _maketest(p, s, n)
 
 
     def test_decimal_e(self):
@@ -997,7 +997,7 @@ class SqlServerTestCase(unittest.TestCase):
         # Create a table (t1) with 3 rows and a view (t2) into it.
         self.cursor.execute("create table t1(c1 int identity(1, 1), c2 varchar(50))")
         for i in range(3):
-            self.cursor.execute("insert into t1(c2) values (?)", "string%s" % i)
+            self.cursor.execute("insert into t1(c2) values (?)", "string{0!s}".format(i))
         self.cursor.execute("create view t2 as select * from t1")
 
         # Select from the view

--- a/tests3/testutils.py
+++ b/tests3/testutils.py
@@ -14,11 +14,11 @@ def add_to_path():
     import imp
 
     library_exts  = [ t[0] for t in imp.get_suffixes() if t[-1] == imp.C_EXTENSION ]
-    library_names = [ 'pyodbc%s' % ext for ext in library_exts ]
+    library_names = [ 'pyodbc{0!s}'.format(ext) for ext in library_exts ]
 
     # Only go into directories that match our version number.
 
-    dir_suffix = '-%s.%s' % (sys.version_info[0], sys.version_info[1])
+    dir_suffix = '-{0!s}.{1!s}'.format(sys.version_info[0], sys.version_info[1])
 
     build = join(dirname(dirname(abspath(__file__))), 'build')
 
@@ -37,23 +37,23 @@ def add_to_path():
 
 def print_library_info(cnxn):
     import pyodbc
-    print('python:  %s' % sys.version)
-    print('pyodbc:  %s %s' % (pyodbc.version, os.path.abspath(pyodbc.__file__)))
-    print('odbc:    %s' % cnxn.getinfo(pyodbc.SQL_ODBC_VER))
-    print('driver:  %s %s' % (cnxn.getinfo(pyodbc.SQL_DRIVER_NAME), cnxn.getinfo(pyodbc.SQL_DRIVER_VER)))
-    print('         supports ODBC version %s' % cnxn.getinfo(pyodbc.SQL_DRIVER_ODBC_VER))
-    print('os:      %s' % platform.system())
-    print('unicode: Py_Unicode=%s SQLWCHAR=%s' % (pyodbc.UNICODE_SIZE, pyodbc.SQLWCHAR_SIZE))
+    print('python:  {0!s}'.format(sys.version))
+    print('pyodbc:  {0!s} {1!s}'.format(pyodbc.version, os.path.abspath(pyodbc.__file__)))
+    print('odbc:    {0!s}'.format(cnxn.getinfo(pyodbc.SQL_ODBC_VER)))
+    print('driver:  {0!s} {1!s}'.format(cnxn.getinfo(pyodbc.SQL_DRIVER_NAME), cnxn.getinfo(pyodbc.SQL_DRIVER_VER)))
+    print('         supports ODBC version {0!s}'.format(cnxn.getinfo(pyodbc.SQL_DRIVER_ODBC_VER)))
+    print('os:      {0!s}'.format(platform.system()))
+    print('unicode: Py_Unicode={0!s} SQLWCHAR={1!s}'.format(pyodbc.UNICODE_SIZE, pyodbc.SQLWCHAR_SIZE))
 
     cursor = cnxn.cursor()
     for typename in ['VARCHAR', 'WVARCHAR', 'BINARY']:
         t = getattr(pyodbc, 'SQL_' + typename)
         cursor.getTypeInfo(t)
         row = cursor.fetchone()
-        print('Max %s = %s' % (typename, row and row[2] or '(not supported)'))
+        print('Max {0!s} = {1!s}'.format(typename, row and row[2] or '(not supported)'))
 
     if platform.system() == 'Windows':
-        print('         %s' % ' '.join([s for s in platform.win32_ver() if s]))
+        print('         {0!s}'.format(' '.join([s for s in platform.win32_ver() if s])))
 
 
 
@@ -69,7 +69,7 @@ def load_tests(testclass, name, *args):
     """
     if name:
         if not name.startswith('test_'):
-            name = 'test_%s' % name
+            name = 'test_{0!s}'.format(name)
         names = [ name ]
 
     else:
@@ -98,7 +98,7 @@ def load_setup_connection_string(section):
             p = SafeConfigParser()
             p.read(path)
         except:
-            raise SystemExit('Unable to parse %s: %s' % (path, sys.exc_info()[1]))
+            raise SystemExit('Unable to parse {0!s}: {1!s}'.format(path, sys.exc_info()[1]))
 
         if p.has_option(section, KEY):
             return p.get(section, KEY)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:nschonni:pyodbc?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:nschonni:pyodbc?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)